### PR TITLE
fix: Add missing IDs to initial book data

### DIFF
--- a/backend/data/library.json
+++ b/backend/data/library.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
     "title": "God of Fury",
     "author": "Rina Kent",
     "owned": "Yes",
@@ -10,6 +11,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d480",
     "title": "Does It Hurt?",
     "author": "H.D. Carlton",
     "owned": "Yes",
@@ -20,6 +22,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d481",
     "title": "A Court of Thorns and Roses",
     "author": "Sarah J. Maas",
     "owned": "Yes",
@@ -30,6 +33,7 @@
     "spice_level": "Medium"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d482",
     "title": "Flock",
     "author": "Kate Stewart",
     "owned": "Yes",
@@ -40,6 +44,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d483",
     "title": "Exodus",
     "author": "Kate Stewart",
     "owned": "Yes",
@@ -50,6 +55,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d484",
     "title": "The Finish Line",
     "author": "Kate Stewart",
     "owned": "Yes",
@@ -60,6 +66,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d485",
     "title": "One Last Rainy Day",
     "author": "Kate Stewart",
     "owned": "Yes",
@@ -70,6 +77,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d486",
     "title": "Severed Heart",
     "author": "Kate Stewart",
     "owned": "Yes",
@@ -80,6 +88,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d487",
     "title": "Lights Out",
     "author": "Navessa Allen",
     "owned": "Yes",
@@ -90,6 +99,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d488",
     "title": "Caught Up",
     "author": "Navessa Allen",
     "owned": "Yes",
@@ -100,6 +110,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d489",
     "title": "Den of Vipers",
     "author": "K.A. Knight",
     "owned": "Yes",
@@ -110,6 +121,7 @@
     "spice_level": "Extra High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d490",
     "title": "Kiss of the Basilisk",
     "author": "Lindsay Straube",
     "owned": "Yes",
@@ -120,6 +132,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d491",
     "title": "The Sacrifice",
     "author": "Shantel Tessier",
     "owned": "Yes",
@@ -130,6 +143,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d492",
     "title": "The Sinner",
     "author": "Shantel Tessier",
     "owned": "Yes",
@@ -140,6 +154,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d493",
     "title": "Phantom",
     "author": "H.D. Carlton",
     "owned": "Yes",
@@ -150,6 +165,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d494",
     "title": "Gravity",
     "author": "Sara Cate",
     "owned": "Yes",
@@ -160,6 +176,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d495",
     "title": "Free Fall",
     "author": "Sara Cate",
     "owned": "Yes",
@@ -170,6 +187,7 @@
     "spice_level": "Extra High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d496",
     "title": "The Brit",
     "author": "Jodi Ellen Malpas",
     "owned": "Yes",
@@ -180,6 +198,7 @@
     "spice_level": "High"
   },
   {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d497",
     "title": "Watch Your Back",
     "author": "Tate James",
     "owned": "Yes",

--- a/backend/data/recommended.json
+++ b/backend/data/recommended.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
     "title": "Butcher & Blackbird",
     "author": "Brynne Weaver",
     "genre/theme": "Dark Romantic Comedy / Murder",
@@ -7,6 +8,7 @@
     "spice_level": "High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde0",
     "title": "Credence",
     "author": "Penelope Douglas",
     "genre/theme": "Forbidden Taboo Romance",
@@ -14,6 +16,7 @@
     "spice_level": "Extra High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde1",
     "title": "There Are No Saints",
     "author": "Sophie Lark",
     "genre/theme": "Dark Obsession Romance",
@@ -21,6 +24,7 @@
     "spice_level": "High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde2",
     "title": "Devourer of Men",
     "author": "Nikki St. Crowe",
     "genre/theme": "Dark Fantasy Romance",
@@ -28,6 +32,7 @@
     "spice_level": "High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde3",
     "title": "The Serpent and the Wings of Night",
     "author": "Carissa Broadbent",
     "genre/theme": "Romantasy / Tournament",
@@ -35,6 +40,7 @@
     "spice_level": "Medium-High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde4",
     "title": "Twisted Love",
     "author": "Ana Huang",
     "genre/theme": "Brother’s Best Friend Romance",
@@ -42,6 +48,7 @@
     "spice_level": "Medium"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde5",
     "title": "Mindf*ck Series",
     "author": "S.T. Abby",
     "genre/theme": "Dark Romantic Suspense",
@@ -49,6 +56,7 @@
     "spice_level": "Extra High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde6",
     "title": "Ruthless Creatures",
     "author": "J.T. Geissinger",
     "genre/theme": "Mafia Romance / Suspense",
@@ -56,6 +64,7 @@
     "spice_level": "Medium-High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde7",
     "title": "King of Battle and Blood",
     "author": "Scarlett St. Clair",
     "genre/theme": "Dark Paranormal Romance",
@@ -63,6 +72,7 @@
     "spice_level": "High"
   },
   {
+    "id": "a1b2c3d4-e5f6-7890-1234-567890abcde8",
     "title": "Kingdom of the Wicked",
     "author": "Kerri Maniscalco",
     "genre/theme": "YA Romantasy / Murder Mystery",

--- a/backend/data/upcoming.json
+++ b/backend/data/upcoming.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcdef",
     "title": "Sweet Venom (Vipers #2)",
     "author": "Rina Kent",
     "release_date": "2025-12-02",
@@ -8,6 +9,7 @@
     "notes": "Standalone dark enemies-to-lovers story"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde0",
     "title": "Painted Sinners Duet #2",
     "author": "Elena Lawson",
     "release_date": "2026-01-06",
@@ -16,6 +18,7 @@
     "notes": "Conclusion to the dark duet"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde1",
     "title": "Mason’s Story (Manhattan Ruthless)",
     "author": "Sadie Kincaid",
     "release_date": "2026-02-28",
@@ -24,6 +27,7 @@
     "notes": "Part of the Manhattan Ruthless series"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde2",
     "title": "MDD",
     "author": "H.D. Carlton",
     "release_date": "2026-03-20",
@@ -32,6 +36,7 @@
     "notes": "New standalone by the author of Does It Hurt?"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde3",
     "title": "Hunt the Villain (Villain #2)",
     "author": "Rina Kent",
     "release_date": "2026-03-24",
@@ -40,6 +45,7 @@
     "notes": "Male–male dark rivals romance set in Legacy of Gods world"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde4",
     "title": "Upon Buried Embers (Dark Romantasy #1)",
     "author": "Kelly Cove",
     "release_date": "2026-03-31",
@@ -48,6 +54,7 @@
     "notes": "Dragonbond and Viking vibes"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde5",
     "title": "King of Gluttony (Kings of Sin #6)",
     "author": "Ana Huang",
     "release_date": "2026-04-28",
@@ -56,6 +63,7 @@
     "notes": "Part of the Kings of Sin series"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde6",
     "title": "Valeria and Enzo’s Story",
     "author": "Catharina Maura",
     "release_date": "2026-08-19",
@@ -64,6 +72,7 @@
     "notes": "Emotional intensity expected"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde7",
     "title": "Arkana",
     "author": "RuNyx",
     "release_date": "2026-01-01",
@@ -72,6 +81,7 @@
     "notes": "Sorceress and villain in gothic setting"
   },
   {
+    "id": "b1c2d3e4-f5g6-7890-1234-567890abcde8",
     "title": "Vipers #3",
     "author": "Rina Kent",
     "release_date": "2026-01-01",


### PR DESCRIPTION
This commit fixes a bug where editing existing books would fail. The root cause was that the initial seed data in the JSON files was missing the unique `id` field that the update and delete logic relies on.

This change adds a unique `id` to every book object in `library.json`, `recommended.json`, and `upcoming.json`. This ensures that all books, including the pre-existing ones, can be correctly identified and modified by the backend API.