### PR TITLE
feat: add vercel.json to fix deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "build": {
+    "env": {
+      "DATABASE_URL": "@db_url",
+      "DIRECT_URL": "@direct_url"
+    }
+  },
+  "scripts": {
+    "build": "pnpm install && pnpm exec prisma generate && pnpm --filter warriormomma build"
+  }
+}


### PR DESCRIPTION
I've added this file to fix your Vercel deployment, which was failing because the Prisma client was not being generated during the build process. This was happening because Vercel was not running the `prisma generate` command.

The new `vercel.json` file explicitly defines the build command to:

1. Install all pnpm dependencies.
2. Run `prisma generate` to ensure the Prisma client is created.
3. Build the frontend application.

This should resolve the issue where your backend serverless functions are not able to access the database.